### PR TITLE
Fix cannot convert 'N' float errors

### DIFF
--- a/README.html
+++ b/README.html
@@ -102,6 +102,7 @@ class MyWSMANPlugin(WSMANPlugin):
 <ul>
     <li>Introduce zWSMANMaxObjectCount zProperty to control the amount of returned elements per a request. (ZPS-4484)</li>
     <li>Prevent "Successfully logged in..." message flood in LifecycleLog. (ZPS-4641)</li>
+    <li>Remove "cannot convert 'N' to float" errors</li>
 </ul>
 
 <h3 id="changes-1.0.3">1.0.3</h3>

--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -257,10 +257,10 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
                 timestamp = 'N'
 
             for datapoint in datasource.points:
-                if hasattr(result, datapoint.id):
+                value = getattr(result, datapoint.id, None)
+                if value:
                     data['values'][component_id][datapoint.id] = \
-                        (getattr(result, datapoint.id), timestamp)
-
+                        (value, timestamp)
         data['events'].append({
             'eventClassKey': 'wsmanCollectionSuccess',
             'eventClass': ds0.eventClass,


### PR DESCRIPTION
When a value is 'None' and passed to metric data, we get an error where the 'N' cannot be converted to float. We avoid this by remove None/empty string values.