### PR TITLE
ZPS-4759 - fixes no event generated on modeling and monitoring when SSL is set to false

### DIFF
--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -45,6 +45,9 @@ def string_to_lines(string):
 
 
 def get_client(datasource, config):
+    if not datasource.zWSMANUseSSL:
+        log.warning("SSL not enabled for %s", config.id)
+
     conn_info = txwsman_util.ConnectionInfo(
         hostname=config.manageIp,
         auth_type='basic',

--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -23,6 +23,9 @@ from Products.Zuul.infos import ProxyProperty
 from Products.Zuul.infos.template import RRDDataSourceInfo
 from Products.Zuul.interfaces import IRRDDataSourceInfo
 from Products.Zuul.utils import ZuulMessageFactory as _t
+from Products.ZenEvents import ZenEventClasses
+from Products.ZenCollector.interfaces import IEventService
+from zope.component import getUtility
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSource, PythonDataSourcePlugin
@@ -45,8 +48,28 @@ def string_to_lines(string):
 
 
 def get_client(datasource, config):
+    eventService = getUtility(IEventService)
+
     if not datasource.zWSMANUseSSL:
         log.warning("SSL not enabled for %s", config.id)
+        eventService.sendEvent({
+            'device': config.id,
+            'eventKey': "{}|{}".format(config.id, 'wsmanCollectSsl'),
+            'eventClass': config.datasources[0].eventClass,
+            'eventClassKey': 'wsmanCollect',
+            'severity': ZenEventClasses.Warning,
+            'summary': 'WSMAN: SSL not enabled',
+            'message': 'SSL not enabled for {}'.format(config.id),
+        })
+    else:
+        eventService.sendEvent({
+            'device': config.id,
+            'eventKey': "{}|{}".format(config.id, 'wsmanCollectSsl'),
+            'eventClass': config.datasources[0].eventClass,
+            'eventClassKey': 'wsmanCollect',
+            'severity': ZenEventClasses.Clear,
+            'summary': 'WSMAN: SSL enabled',
+        })
 
     conn_info = txwsman_util.ConnectionInfo(
         hostname=config.manageIp,

--- a/ZenPacks/zenoss/WSMAN/modeler/WSMANPlugin.py
+++ b/ZenPacks/zenoss/WSMAN/modeler/WSMANPlugin.py
@@ -92,6 +92,9 @@ class WSMANPlugin(PythonPlugin):
         if more complex collection is required.
         '''
 
+        if not device.zWSMANUseSSL:
+            log.warning("SSL not enabled for %s", device.id)
+
         conn_info = self.conn_info(device)
         client = self.client(conn_info)
 

--- a/ZenPacks/zenoss/WSMAN/modeler/WSMANPlugin.py
+++ b/ZenPacks/zenoss/WSMAN/modeler/WSMANPlugin.py
@@ -94,6 +94,22 @@ class WSMANPlugin(PythonPlugin):
 
         if not device.zWSMANUseSSL:
             log.warning("SSL not enabled for %s", device.id)
+            self._eventService.sendEvent({
+                'device': device.id,
+                'eventKey': "{}|{}".format(device.id, 'wsmanCollectSsl'),
+                'eventClassKey': 'wsmanCollect',
+                'severity': ZenEventClasses.Warning,
+                'summary': 'WSMAN: SSL not enabled',
+                'message': 'SSL not enabled for {}'.format(device.id),
+            })
+        else
+            self._eventService.sendEvent({
+                'device': device.id,
+                'eventKey': "{}|{}".format(device.id, 'wsmanCollectSsl'),
+                'eventClassKey': 'wsmanCollect',
+                'severity': ZenEventClasses.Clear,
+                'summary': 'WSMAN: SSL enabled',
+            })
 
         conn_info = self.conn_info(device)
         client = self.client(conn_info)

--- a/ZenPacks/zenoss/WSMAN/utils.py
+++ b/ZenPacks/zenoss/WSMAN/utils.py
@@ -38,7 +38,8 @@ def result_errmsg(result):
 #            else:
 #                return result.value.args[1]
         else:
-            return result.getErrorMessage()
+            return result.getErrorMessage() + "."\
+                   ' Check IP and zWSMANPort and SSL Settings'
     except AttributeError:
         pass
 


### PR DESCRIPTION
 * https://jira.zenoss.com/browse/ZPS-4759
 * added events and log messages to indicate SSL is off
 * customer have requested both monitoring and modeling to produce events in https://zenoss.zendesk.com/agent/tickets/149859
 * set severity to Warning