### PR TITLE
Change the default WSMAN event class

### DIFF
--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -290,7 +290,7 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
 
         data['events'].append({
             'eventClassKey': 'wsmanCollectionSuccess',
-            'eventClass': ds0.eventClass,
+            'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
             'eventKey': eventKey(config),
             'summary': 'WSMAN: successful collection',
             'device': config.id,
@@ -304,14 +304,14 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
         log.error('%s %s', config.id, errmsg)
 
         data = self.new_data()
-        eventClass = config.datasources[0].eventClass
+        ds0 = config.datasources[0]
         data['events'].append({
             'eventClassKey': 'wsmanCollectionError',
-            'eventClass': eventClass,
+            'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
             'eventKey': eventKey(config),
             'summary': errmsg,
             'device': config.id,
-            'severity': config.datasources[0].severity,
+            'severity': ds0.severity,
         })
 
         return data

--- a/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
@@ -57,9 +57,9 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(event['severity'], ZenEventClasses.Clear)
 
         # plugin will return empty string as an eventClass, but it will be
-        # transformed to '/Unknown'. So empty string is expected behaviour in
+        # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case
-        self.assertEquals(event['eventClass'], '')
+        self.assertEquals(event['eventClass'], '/Status/PowerEdge')
 
     def test_onError(self):
         f = Failure(Exception('test_onError'))
@@ -72,9 +72,9 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(event['severity'], ZenEventClasses.Error)
 
         # plugin will return empty string as an eventClass, but it will be
-        # transformed to '/Unknown'. So empty string is expected behaviour in
+        # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case
-        self.assertEquals(event['eventClass'], '')
+        self.assertEquals(event['eventClass'], '/Status/PowerEdge')
 
     def test_onSuccess_event_class_defined(self):
         event_class = '/Status/UserDefined'


### PR DESCRIPTION
Fixes ZPS-7979.

Changed default WSMAN event class from '/Unknown' to '/Status/PowerEdge'.
Fixed unit tests.