### PR TITLE
Fixed WSMAN event clearing in the base datasource

### DIFF
--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -291,6 +291,7 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
         data['events'].append({
             'eventClassKey': 'wsmanCollectionSuccess',
             'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
+            'component': ds0.component,
             'eventKey': eventKey(config),
             'summary': 'WSMAN: successful collection',
             'device': config.id,
@@ -309,7 +310,10 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
             'eventClassKey': 'wsmanCollectionError',
             'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
             'eventKey': eventKey(config),
-            'summary': errmsg,
+            'component': ds0.component,
+            'summary': 'Unsuccessful collection for a datasource - {}. '
+                       'Check event details for the error message.'.format(ds0.datasource),
+            'message': errmsg,
             'device': config.id,
             'severity': ds0.severity,
         })

--- a/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/datasources/WSMANDataSource.py
@@ -291,7 +291,6 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
         data['events'].append({
             'eventClassKey': 'wsmanCollectionSuccess',
             'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
-            'component': ds0.component,
             'eventKey': eventKey(config),
             'summary': 'WSMAN: successful collection',
             'device': config.id,
@@ -310,7 +309,6 @@ class WSMANDataSourcePlugin(PythonDataSourcePlugin):
             'eventClassKey': 'wsmanCollectionError',
             'eventClass': ds0.eventClass if ds0.eventClass else '/Status/PowerEdge',
             'eventKey': eventKey(config),
-            'component': ds0.component,
             'summary': 'Unsuccessful collection for a datasource - {}. '
                        'Check event details for the error message.'.format(ds0.datasource),
             'message': errmsg,

--- a/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
@@ -55,7 +55,8 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['values']), 6)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(event['severity'], ZenEventClasses.Clear)
-
+        self.assertEquals(event['component'], '5000C5005EAE2971')
+        self.assertEquals('5000C5005EAE2971' in event['eventKey'], True)
         # plugin will return empty string as an eventClass, but it will be
         # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case
@@ -70,7 +71,8 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['values']), 0)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(event['severity'], ZenEventClasses.Error)
-
+        self.assertEquals(event['component'], '5000C5005EAE2971')
+        self.assertEquals('5000C5005EAE2971' in event['eventKey'], True)
         # plugin will return empty string as an eventClass, but it will be
         # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case

--- a/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
+++ b/ZenPacks/zenoss/WSMAN/tests/testWSMANDataSource.py
@@ -55,8 +55,6 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['values']), 6)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(event['severity'], ZenEventClasses.Clear)
-        self.assertEquals(event['component'], '5000C5005EAE2971')
-        self.assertEquals('5000C5005EAE2971' in event['eventKey'], True)
         # plugin will return empty string as an eventClass, but it will be
         # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case
@@ -71,8 +69,6 @@ class TestWSMANDataSourcePlugin(BaseTestCase):
         self.assertEquals(len(data['values']), 0)
         self.assertEquals(len(data['events']), 1)
         self.assertEquals(event['severity'], ZenEventClasses.Error)
-        self.assertEquals(event['component'], '5000C5005EAE2971')
-        self.assertEquals('5000C5005EAE2971' in event['eventKey'], True)
         # plugin will return empty string as an eventClass, but it will be
         # transformed to '/Status/PowerEdge'. So empty string is expected behaviour in
         # this case

--- a/ZenPacks/zenoss/WSMAN/utils.py
+++ b/ZenPacks/zenoss/WSMAN/utils.py
@@ -49,4 +49,4 @@ def result_errmsg(result):
 def eventKey(config):
     '''Given a config, return an appropriate eventKey.'''
     ds0 = config.datasources[0]
-    return '%s|%s|%s' % (ds0.plugin_classname, ds0.component, ds0.datasource)
+    return '%s|%s|%s' % (ds0.plugin_classname, ds0.params.get('CIMClass', ''), ds0.datasource)

--- a/ZenPacks/zenoss/WSMAN/utils.py
+++ b/ZenPacks/zenoss/WSMAN/utils.py
@@ -31,7 +31,7 @@ def result_errmsg(result):
             return 'connection timeout.'\
                    ' Check IP and zWSMANPort and SSL Settings'
         elif result.type == NameError:
-            return 'Invalid CIM Class.  Class not found.'
+            return 'Invalid CIM Class. Class not found.'
 #        elif result.type == CIMError:
 #            if '401' in result.value.args[1]:
 #                return 'login failed. Check zWSMANUsername and zWSMANPassword'
@@ -49,4 +49,4 @@ def result_errmsg(result):
 def eventKey(config):
     '''Given a config, return an appropriate eventKey.'''
     ds0 = config.datasources[0]
-    return '%s|%s|%s' % (ds0.plugin_classname, ds0.cycletime, ds0.datasource)
+    return '%s|%s|%s' % (ds0.plugin_classname, ds0.component, ds0.datasource)


### PR DESCRIPTION
Fixes ZPS-8620.

Changed eventKey generation for the WSMAN events.
Added component field to the event.
Changed summary and moved error message to the event message field. 
Updated unit tests.